### PR TITLE
fix: replace deprecated anonymous matrix function syntax

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: format diff
         run: |
-          moon fmt --block-style
+          moon fmt
           git diff --exit-code
 
       - name: Setup MSVC

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -110,17 +110,6 @@ jobs:
           moon test --target all,native
           moon test --target all,native --release
 
-      - name: moon test with dedup_wasm
-        if: ${{ matrix.os.name != 'windows-latest' }}
-        env: 
-          MOONC_INTERNAL_PARAMS: dedup_wasm = 1 |
-
-        run: |
-          moon clean
-          ulimit -s 8176
-          moon test --target wasm,wasm-gc
-          moon test --target wasm,wasm-gc --release 
-
       - name: moon test --doc
         run: |
           moon test --doc

--- a/src/alias.mbt
+++ b/src/alias.mbt
@@ -1,138 +1,180 @@
 ///|
-pub typealias Arrow[A, B] = (A) -> B
+pub typealias (A) -> B as Arrow[A, B]
 
 ///|
-pub typealias Arrow2[A, B, C] = (A) -> (B) -> C
+pub typealias (A) -> (B) -> C as Arrow2[A, B, C]
 
 ///|
-pub typealias Arrow3[A, B, C, D] = (A) -> (B) -> (C) -> D
+pub typealias (A) -> (B) -> (C) -> D as Arrow3[A, B, C, D]
 
 ///|
-pub typealias Arrow4[A, B, C, D, E] = (A) -> (B) -> (C) -> (D) -> E
+pub typealias (A) -> (B) -> (C) -> (D) -> E as Arrow4[A, B, C, D, E]
 
 ///|
-pub typealias Arrow5[A, B, C, D, E, F] = (A) -> (B) -> (C) -> (D) -> (E) -> F
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> F as Arrow5[A, B, C, D, E, F]
 
 ///|
-pub typealias Arrow6[A, B, C, D, E, F, G] = (A) -> (B) -> (C) -> (D) -> (E) -> (
-  F,
-) -> G
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G as
+Arrow6[A, B, C, D, E, F, G]
 
 ///|
-pub typealias Arrow7[A, B, C, D, E, F, G, H] = (A) -> (B) -> (C) -> (D) -> (E) -> (
-  F,
-) -> (G) -> H
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H as
+Arrow7[A, B, C, D, E, F, G, H]
 
 ///|
-pub typealias Arrow8[A, B, C, D, E, F, G, H, I] = (A) -> (B) -> (C) -> (D) -> (
-  E,
-) -> (F) -> (G) -> (H) -> I
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I as
+Arrow8[A, B, C, D, E, F, G, H, I]
 
 ///|
-pub typealias Arrow9[A, B, C, D, E, F, G, H, I, J] = (A) -> (B) -> (C) -> (D) -> (
-  E,
-) -> (F) -> (G) -> (H) -> (I) -> J
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J as
+Arrow9[A, B, C, D, E, F, G, H, I, J]
 
 ///|
-pub typealias Arrow10[A, B, C, D, E, F, G, H, I, J, K] = (A) -> (B) -> (C) -> (
-  D,
-) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K as
+Arrow10[A, B, C, D, E, F, G, H, I, J, K]
 
 ///|
-pub typealias Arrow11[A, B, C, D, E, F, G, H, I, J, K, L] = (A) -> (B) -> (C) -> (
-  D,
-) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> L as Arrow11[A, B, C, D, E, F, G, H, I, J, K, L]
 
 ///|
-pub typealias Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M] = (A) -> (B) -> (C) -> (
-  D,
-) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> M as Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M]
 
 ///|
-pub typealias Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N] = (A) -> (B) -> (
-  C,
-) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> N as Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
 
 ///|
-pub typealias Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] = (A) -> (B) -> (
-  C,
-) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> O as
+Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 
 ///|
-pub typealias Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] = (A) -> (
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> P as
+Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q as
+Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R as
+Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S as
+Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T as
+Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U as
+Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V as
+Arrow21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W as
+Arrow22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (
+  W,
+) -> X as
+Arrow23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (
+  W,
+) -> (X) -> Y as
+Arrow24[
+  A,
   B,
-) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
   N,
-) -> (O) -> P
-
-///|
-pub typealias Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] = (A) -> (
-  B,
-) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (
-  N,
-) -> (O) -> (P) -> Q
-
-///|
-pub typealias Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> R
-
-///|
-pub typealias Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S
-
-///|
-pub typealias Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T
-
-///|
-pub typealias Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U
-
-///|
-pub typealias Arrow21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V
-
-///|
-pub typealias Arrow22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W
-
-///|
-pub typealias Arrow23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X
-
-///|
-pub typealias Arrow24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y
-
-///|
-pub typealias Arrow25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z] = (
-  A,
-) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (
-  M,
-) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
   Y,
-) -> Z
+]
+
+///|
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
+  K,
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (
+  W,
+) -> (X) -> (Y) -> Z as
+Arrow25[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+]

--- a/src/alias.mbt
+++ b/src/alias.mbt
@@ -14,24 +14,19 @@ pub typealias (A) -> (B) -> (C) -> (D) -> E as Arrow4[A, B, C, D, E]
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> F as Arrow5[A, B, C, D, E, F]
 
 ///|
-pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G as
-Arrow6[A, B, C, D, E, F, G]
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G as Arrow6[A, B, C, D, E, F, G]
 
 ///|
-pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H as
-Arrow7[A, B, C, D, E, F, G, H]
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H as Arrow7[A, B, C, D, E, F, G, H]
 
 ///|
-pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I as
-Arrow8[A, B, C, D, E, F, G, H, I]
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I as Arrow8[A, B, C, D, E, F, G, H, I]
 
 ///|
-pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J as
-Arrow9[A, B, C, D, E, F, G, H, I, J]
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J as Arrow9[A, B, C, D, E, F, G, H, I, J]
 
 ///|
-pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K as
-Arrow10[A, B, C, D, E, F, G, H, I, J, K]
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K as Arrow10[A, B, C, D, E, F, G, H, I, J, K]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
@@ -51,130 +46,65 @@ pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J)
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> O as
-Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+) -> (L) -> (M) -> (N) -> O as Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> P as
-Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+) -> (L) -> (M) -> (N) -> (O) -> P as Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q as
-Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q as Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R as
-Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R as Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S as
-Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S as Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T as
-Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T as Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U as
-Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U as Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V as
-Arrow21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V as Arrow21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
-) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W as
-Arrow22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]
+) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W as Arrow22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
 ) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (
   W,
-) -> X as
-Arrow23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X]
+) -> X as Arrow23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
 ) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (
   W,
-) -> (X) -> Y as
-Arrow24[
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  P,
-  Q,
-  R,
-  S,
-  T,
-  U,
-  V,
-  W,
-  X,
-  Y,
-]
+) -> (X) -> Y as Arrow24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y]
 
 ///|
 pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (
   K,
 ) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (
   W,
-) -> (X) -> (Y) -> Z as
-Arrow25[
-  A,
-  B,
-  C,
-  D,
-  E,
-  F,
-  G,
-  H,
-  I,
-  J,
-  K,
-  L,
-  M,
-  N,
-  O,
-  P,
-  Q,
-  R,
-  S,
-  T,
-  U,
-  V,
-  W,
-  X,
-  Y,
-  Z,
-]
+) -> (X) -> (Y) -> Z as Arrow25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]

--- a/src/apply.mbt
+++ b/src/apply.mbt
@@ -1,56 +1,56 @@
 ///|
-pub fn apply1[A, B](func : Arrow[A, B], a : A) -> B {
+pub fn[A, B] apply1(func : Arrow[A, B], a : A) -> B {
   func(a)
 }
 
 ///|
-pub fn apply2[A, B, C](func : Arrow2[A, B, C], a : A, b : B) -> C {
+pub fn[A, B, C] apply2(func : Arrow2[A, B, C], a : A, b : B) -> C {
   func(a)(b)
 }
 
 ///|
-pub fn apply3[A, B, C, D](func : Arrow3[A, B, C, D], a : A, b : B, c : C) -> D {
+pub fn[A, B, C, D] apply3(func : Arrow3[A, B, C, D], a : A, b : B, c : C) -> D {
   func(a)(b)(c)
 }
 
 ///|
-pub fn apply4[A, B, C, D, E](
+pub fn[A, B, C, D, E] apply4(
   func : Arrow4[A, B, C, D, E],
   a : A,
   b : B,
   c : C,
-  d : D
+  d : D,
 ) -> E {
   func(a)(b)(c)(d)
 }
 
 ///|
-pub fn apply5[A, B, C, D, E, F](
+pub fn[A, B, C, D, E, F] apply5(
   func : Arrow5[A, B, C, D, E, F],
   a : A,
   b : B,
   c : C,
   d : D,
-  e : E
+  e : E,
 ) -> F {
   func(a)(b)(c)(d)(e)
 }
 
 ///|
-pub fn apply6[A, B, C, D, E, F, G](
+pub fn[A, B, C, D, E, F, G] apply6(
   func : Arrow6[A, B, C, D, E, F, G],
   a : A,
   b : B,
   c : C,
   d : D,
   e : E,
-  f : F
+  f : F,
 ) -> G {
   func(a)(b)(c)(d)(e)(f)
 }
 
 ///|
-pub fn apply7[A, B, C, D, E, F, G, H](
+pub fn[A, B, C, D, E, F, G, H] apply7(
   func : Arrow7[A, B, C, D, E, F, G, H],
   a : A,
   b : B,
@@ -58,13 +58,13 @@ pub fn apply7[A, B, C, D, E, F, G, H](
   d : D,
   e : E,
   f : F,
-  g : G
+  g : G,
 ) -> H {
   func(a)(b)(c)(d)(e)(f)(g)
 }
 
 ///|
-pub fn apply8[A, B, C, D, E, F, G, H, I](
+pub fn[A, B, C, D, E, F, G, H, I] apply8(
   func : Arrow8[A, B, C, D, E, F, G, H, I],
   a : A,
   b : B,
@@ -73,13 +73,13 @@ pub fn apply8[A, B, C, D, E, F, G, H, I](
   e : E,
   f : F,
   g : G,
-  h : H
+  h : H,
 ) -> I {
   func(a)(b)(c)(d)(e)(f)(g)(h)
 }
 
 ///|
-pub fn apply9[A, B, C, D, E, F, G, H, I, J](
+pub fn[A, B, C, D, E, F, G, H, I, J] apply9(
   func : Arrow9[A, B, C, D, E, F, G, H, I, J],
   a : A,
   b : B,
@@ -89,13 +89,13 @@ pub fn apply9[A, B, C, D, E, F, G, H, I, J](
   f : F,
   g : G,
   h : H,
-  i : I
+  i : I,
 ) -> J {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)
 }
 
 ///|
-pub fn apply10[A, B, C, D, E, F, G, H, I, J, K](
+pub fn[A, B, C, D, E, F, G, H, I, J, K] apply10(
   func : Arrow10[A, B, C, D, E, F, G, H, I, J, K],
   a : A,
   b : B,
@@ -106,13 +106,13 @@ pub fn apply10[A, B, C, D, E, F, G, H, I, J, K](
   g : G,
   h : H,
   i : I,
-  j : J
+  j : J,
 ) -> K {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)
 }
 
 ///|
-pub fn apply11[A, B, C, D, E, F, G, H, I, J, K, L](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L] apply11(
   func : Arrow11[A, B, C, D, E, F, G, H, I, J, K, L],
   a : A,
   b : B,
@@ -124,13 +124,13 @@ pub fn apply11[A, B, C, D, E, F, G, H, I, J, K, L](
   h : H,
   i : I,
   j : J,
-  k : K
+  k : K,
 ) -> L {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)
 }
 
 ///|
-pub fn apply12[A, B, C, D, E, F, G, H, I, J, K, L, M](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M] apply12(
   func : Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M],
   a : A,
   b : B,
@@ -143,13 +143,13 @@ pub fn apply12[A, B, C, D, E, F, G, H, I, J, K, L, M](
   i : I,
   j : J,
   k : K,
-  l : L
+  l : L,
 ) -> M {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)
 }
 
 ///|
-pub fn apply13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N] apply13(
   func : Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N],
   a : A,
   b : B,
@@ -163,13 +163,13 @@ pub fn apply13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](
   j : J,
   k : K,
   l : L,
-  m : M
+  m : M,
 ) -> N {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)
 }
 
 ///|
-pub fn apply14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] apply14(
   func : Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O],
   a : A,
   b : B,
@@ -184,13 +184,13 @@ pub fn apply14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](
   k : K,
   l : L,
   m : M,
-  n : N
+  n : N,
 ) -> O {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)
 }
 
 ///|
-pub fn apply15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] apply15(
   func : Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P],
   a : A,
   b : B,
@@ -206,13 +206,13 @@ pub fn apply15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](
   l : L,
   m : M,
   n : N,
-  o : O
+  o : O,
 ) -> P {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)
 }
 
 ///|
-pub fn apply16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] apply16(
   func : Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q],
   a : A,
   b : B,
@@ -229,13 +229,13 @@ pub fn apply16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](
   m : M,
   n : N,
   o : O,
-  p : P
+  p : P,
 ) -> Q {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)
 }
 
 ///|
-pub fn apply17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] apply17(
   func : Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R],
   a : A,
   b : B,
@@ -253,13 +253,13 @@ pub fn apply17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](
   n : N,
   o : O,
   p : P,
-  q : Q
+  q : Q,
 ) -> R {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)
 }
 
 ///|
-pub fn apply18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] apply18(
   func : Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S],
   a : A,
   b : B,
@@ -278,13 +278,13 @@ pub fn apply18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](
   o : O,
   p : P,
   q : Q,
-  r : R
+  r : R,
 ) -> S {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)
 }
 
 ///|
-pub fn apply19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] apply19(
   func : Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T],
   a : A,
   b : B,
@@ -304,13 +304,13 @@ pub fn apply19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
   p : P,
   q : Q,
   r : R,
-  s : S
+  s : S,
 ) -> T {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)
 }
 
 ///|
-pub fn apply20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] apply20(
   func : Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U],
   a : A,
   b : B,
@@ -331,13 +331,13 @@ pub fn apply20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
   q : Q,
   r : R,
   s : S,
-  t : T
+  t : T,
 ) -> U {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)
 }
 
 ///|
-pub fn apply21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] apply21(
   func : Arrow21[
     A,
     B,
@@ -382,13 +382,13 @@ pub fn apply21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
   r : R,
   s : S,
   t : T,
-  u : U
+  u : U,
 ) -> V {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)
 }
 
 ///|
-pub fn apply22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] apply22(
   func : Arrow22[
     A,
     B,
@@ -435,13 +435,13 @@ pub fn apply22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
   s : S,
   t : T,
   u : U,
-  v : V
+  v : V,
 ) -> W {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)
 }
 
 ///|
-pub fn apply23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] apply23(
   func : Arrow23[
     A,
     B,
@@ -490,13 +490,39 @@ pub fn apply23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
   t : T,
   u : U,
   v : V,
-  w : W
+  w : W,
 ) -> X {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)(w)
 }
 
 ///|
-pub fn apply24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y](
+pub fn[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+] apply24(
   func : Arrow24[
     A,
     B,
@@ -547,13 +573,40 @@ pub fn apply24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
   u : U,
   v : V,
   w : W,
-  x : X
+  x : X,
 ) -> Y {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)(w)(x)
 }
 
 ///|
-pub fn apply25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z](
+pub fn[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+] apply25(
   func : Arrow25[
     A,
     B,
@@ -606,7 +659,7 @@ pub fn apply25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
   v : V,
   w : W,
   x : X,
-  y : Y
+  y : Y,
 ) -> Z {
   func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)(w)(x)(
     y,

--- a/src/curry.mbt
+++ b/src/curry.mbt
@@ -1,28 +1,28 @@
 ///|
-pub fn curry2[A, B, C](func : (A, B) -> C) -> Arrow2[A, B, C] {
+pub fn[A, B, C] curry2(func : (A, B) -> C) -> Arrow2[A, B, C] {
   fn(a) { fn(b) { func(a, b) } }
 }
 
 ///|
-pub fn curry3[A, B, C, D](func : (A, B, C) -> D) -> Arrow3[A, B, C, D] {
+pub fn[A, B, C, D] curry3(func : (A, B, C) -> D) -> Arrow3[A, B, C, D] {
   fn(a) { fn(b) { fn(c) { func(a, b, c) } } }
 }
 
 ///|
-pub fn curry4[A, B, C, D, E](func : (A, B, C, D) -> E) -> Arrow4[A, B, C, D, E] {
+pub fn[A, B, C, D, E] curry4(func : (A, B, C, D) -> E) -> Arrow4[A, B, C, D, E] {
   fn(a) { fn(b) { fn(c) { fn(d) { func(a, b, c, d) } } } }
 }
 
 ///|
-pub fn curry5[A, B, C, D, E, F](
-  func : (A, B, C, D, E) -> F
+pub fn[A, B, C, D, E, F] curry5(
+  func : (A, B, C, D, E) -> F,
 ) -> Arrow5[A, B, C, D, E, F] {
   fn(a) { fn(b) { fn(c) { fn(d) { fn(e) { func(a, b, c, d, e) } } } } }
 }
 
 ///|
-pub fn curry6[A, B, C, D, E, F, G](
-  func : (A, B, C, D, E, F) -> G
+pub fn[A, B, C, D, E, F, G] curry6(
+  func : (A, B, C, D, E, F) -> G,
 ) -> Arrow6[A, B, C, D, E, F, G] {
   fn(a) {
     fn(b) { fn(c) { fn(d) { fn(e) { fn(f) { func(a, b, c, d, e, f) } } } } }
@@ -30,8 +30,8 @@ pub fn curry6[A, B, C, D, E, F, G](
 }
 
 ///|
-pub fn curry7[A, B, C, D, E, F, G, H](
-  func : (A, B, C, D, E, F, G) -> H
+pub fn[A, B, C, D, E, F, G, H] curry7(
+  func : (A, B, C, D, E, F, G) -> H,
 ) -> Arrow7[A, B, C, D, E, F, G, H] {
   fn(a) {
     fn(b) {
@@ -43,8 +43,8 @@ pub fn curry7[A, B, C, D, E, F, G, H](
 }
 
 ///|
-pub fn curry8[A, B, C, D, E, F, G, H, I](
-  func : (A, B, C, D, E, F, G, H) -> I
+pub fn[A, B, C, D, E, F, G, H, I] curry8(
+  func : (A, B, C, D, E, F, G, H) -> I,
 ) -> Arrow8[A, B, C, D, E, F, G, H, I] {
   fn(a) {
     fn(b) {
@@ -58,8 +58,8 @@ pub fn curry8[A, B, C, D, E, F, G, H, I](
 }
 
 ///|
-pub fn curry9[A, B, C, D, E, F, G, H, I, J](
-  func : (A, B, C, D, E, F, G, H, I) -> J
+pub fn[A, B, C, D, E, F, G, H, I, J] curry9(
+  func : (A, B, C, D, E, F, G, H, I) -> J,
 ) -> Arrow9[A, B, C, D, E, F, G, H, I, J] {
   fn(a) {
     fn(b) {
@@ -77,8 +77,8 @@ pub fn curry9[A, B, C, D, E, F, G, H, I, J](
 }
 
 ///|
-pub fn curry10[A, B, C, D, E, F, G, H, I, J, K](
-  func : (A, B, C, D, E, F, G, H, I, J) -> K
+pub fn[A, B, C, D, E, F, G, H, I, J, K] curry10(
+  func : (A, B, C, D, E, F, G, H, I, J) -> K,
 ) -> Arrow10[A, B, C, D, E, F, G, H, I, J, K] {
   fn(a) {
     fn(b) {
@@ -98,8 +98,8 @@ pub fn curry10[A, B, C, D, E, F, G, H, I, J, K](
 }
 
 ///|
-pub fn curry11[A, B, C, D, E, F, G, H, I, J, K, L](
-  func : (A, B, C, D, E, F, G, H, I, J, K) -> L
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L] curry11(
+  func : (A, B, C, D, E, F, G, H, I, J, K) -> L,
 ) -> Arrow11[A, B, C, D, E, F, G, H, I, J, K, L] {
   fn(a) {
     fn(b) {
@@ -123,8 +123,8 @@ pub fn curry11[A, B, C, D, E, F, G, H, I, J, K, L](
 }
 
 ///|
-pub fn curry12[A, B, C, D, E, F, G, H, I, J, K, L, M](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L) -> M
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M] curry12(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L) -> M,
 ) -> Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M] {
   fn(a) {
     fn(b) {
@@ -152,8 +152,8 @@ pub fn curry12[A, B, C, D, E, F, G, H, I, J, K, L, M](
 }
 
 ///|
-pub fn curry13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N] curry13(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N,
 ) -> Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N] {
   fn(a) {
     fn(b) {
@@ -183,8 +183,8 @@ pub fn curry13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](
 }
 
 ///|
-pub fn curry14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] curry14(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O,
 ) -> Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] {
   fn(a) {
     fn(b) {
@@ -218,8 +218,8 @@ pub fn curry14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](
 }
 
 ///|
-pub fn curry15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] curry15(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P,
 ) -> Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] {
   fn(a) {
     fn(b) {
@@ -257,8 +257,8 @@ pub fn curry15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](
 }
 
 ///|
-pub fn curry16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] curry16(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q,
 ) -> Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] {
   fn(a) {
     fn(b) {
@@ -299,8 +299,8 @@ pub fn curry16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](
 }
 
 ///|
-pub fn curry17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] curry17(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R,
 ) -> Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] {
   fn(a) {
     fn(b) {
@@ -343,8 +343,8 @@ pub fn curry17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](
 }
 
 ///|
-pub fn curry18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] curry18(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S,
 ) -> Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] {
   fn(a) {
     fn(b) {
@@ -389,8 +389,8 @@ pub fn curry18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](
 }
 
 ///|
-pub fn curry19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] curry19(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T,
 ) -> Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] {
   fn(a) {
     fn(b) {
@@ -437,8 +437,8 @@ pub fn curry19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
 }
 
 ///|
-pub fn curry20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] curry20(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U,
 ) -> Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] {
   fn(a) {
     fn(b) {
@@ -487,8 +487,8 @@ pub fn curry20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
 }
 
 ///|
-pub fn curry21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] curry21(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V,
 ) -> Arrow21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] {
   fn(a) {
     fn(b) {
@@ -539,34 +539,33 @@ pub fn curry21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
 }
 
 ///|
-pub fn curry22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W
-) ->
-     Arrow22[
-       A,
-       B,
-       C,
-       D,
-       E,
-       F,
-       G,
-       H,
-       I,
-       J,
-       K,
-       L,
-       M,
-       N,
-       O,
-       P,
-       Q,
-       R,
-       S,
-       T,
-       U,
-       V,
-       W,
-     ] {
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] curry22(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W,
+) -> Arrow22[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+] {
   fn(a) {
     fn(b) {
       fn(c) {
@@ -618,35 +617,34 @@ pub fn curry22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
 }
 
 ///|
-pub fn curry23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X](
-  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X
-) ->
-     Arrow23[
-       A,
-       B,
-       C,
-       D,
-       E,
-       F,
-       G,
-       H,
-       I,
-       J,
-       K,
-       L,
-       M,
-       N,
-       O,
-       P,
-       Q,
-       R,
-       S,
-       T,
-       U,
-       V,
-       W,
-       X,
-     ] {
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] curry23(
+  func : (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X,
+) -> Arrow23[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+] {
   fn(a) {
     fn(b) {
       fn(c) {
@@ -701,7 +699,33 @@ pub fn curry23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
 }
 
 ///|
-pub fn curry24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y](
+pub fn[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+] curry24(
   func : (
     A,
     B,
@@ -727,35 +751,34 @@ pub fn curry24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
     V,
     W,
     X,
-  ) -> Y
-) ->
-     Arrow24[
-       A,
-       B,
-       C,
-       D,
-       E,
-       F,
-       G,
-       H,
-       I,
-       J,
-       K,
-       L,
-       M,
-       N,
-       O,
-       P,
-       Q,
-       R,
-       S,
-       T,
-       U,
-       V,
-       W,
-       X,
-       Y,
-     ] {
+  ) -> Y,
+) -> Arrow24[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+] {
   fn(a) {
     fn(b) {
       fn(c) {
@@ -812,7 +835,34 @@ pub fn curry24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
 }
 
 ///|
-pub fn curry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z](
+pub fn[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+] curry25(
   func : (
     A,
     B,
@@ -839,36 +889,35 @@ pub fn curry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
     W,
     X,
     Y,
-  ) -> Z
-) ->
-     Arrow25[
-       A,
-       B,
-       C,
-       D,
-       E,
-       F,
-       G,
-       H,
-       I,
-       J,
-       K,
-       L,
-       M,
-       N,
-       O,
-       P,
-       Q,
-       R,
-       S,
-       T,
-       U,
-       V,
-       W,
-       X,
-       Y,
-       Z,
-     ] {
+  ) -> Z,
+) -> Arrow25[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+] {
   fn(a) {
     fn(b) {
       fn(c) {
@@ -927,6 +976,6 @@ pub fn curry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V,
 }
 
 ///| `curry` is `curry2`'s alias
-pub fn curry[A, B, C](f : (A, B) -> C) -> Arrow2[A, B, C] {
+pub fn[A, B, C] curry(f : (A, B) -> C) -> Arrow2[A, B, C] {
   curry2(f)
 }

--- a/src/fun.mbti
+++ b/src/fun.mbti
@@ -1,222 +1,225 @@
-package illusory0x0/fun
+// Generated using `moon info`, DON'T EDIT IT
+package "illusory0x0/fun"
 
 // Values
-fn apply1[A, B]((A) -> B, A) -> B
+fn[A, B] apply1((A) -> B, A) -> B
 
-fn apply10[A, B, C, D, E, F, G, H, I, J, K]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K, A, B, C, D, E, F, G, H, I, J) -> K
+fn[A, B, C, D, E, F, G, H, I, J, K] apply10((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K, A, B, C, D, E, F, G, H, I, J) -> K
 
-fn apply11[A, B, C, D, E, F, G, H, I, J, K, L]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L, A, B, C, D, E, F, G, H, I, J, K) -> L
+fn[A, B, C, D, E, F, G, H, I, J, K, L] apply11((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L, A, B, C, D, E, F, G, H, I, J, K) -> L
 
-fn apply12[A, B, C, D, E, F, G, H, I, J, K, L, M]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M, A, B, C, D, E, F, G, H, I, J, K, L) -> M
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M] apply12((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M, A, B, C, D, E, F, G, H, I, J, K, L) -> M
 
-fn apply13[A, B, C, D, E, F, G, H, I, J, K, L, M, N]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N, A, B, C, D, E, F, G, H, I, J, K, L, M) -> N
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N] apply13((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N, A, B, C, D, E, F, G, H, I, J, K, L, M) -> N
 
-fn apply14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O, A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] apply14((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O, A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O
 
-fn apply15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] apply15((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P
 
-fn apply16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] apply16((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q
 
-fn apply17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] apply17((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R
 
-fn apply18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] apply18((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S
 
-fn apply19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] apply19((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T
 
-fn apply2[A, B, C]((A) -> (B) -> C, A, B) -> C
+fn[A, B, C] apply2((A) -> (B) -> C, A, B) -> C
 
-fn apply20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] apply20((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U
 
-fn apply21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] apply21((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V
 
-fn apply22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] apply22((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W
 
-fn apply23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] apply23((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X
 
-fn apply24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y] apply24((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y
 
-fn apply25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z] apply25((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z, A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z
 
-fn apply3[A, B, C, D]((A) -> (B) -> (C) -> D, A, B, C) -> D
+fn[A, B, C, D] apply3((A) -> (B) -> (C) -> D, A, B, C) -> D
 
-fn apply4[A, B, C, D, E]((A) -> (B) -> (C) -> (D) -> E, A, B, C, D) -> E
+fn[A, B, C, D, E] apply4((A) -> (B) -> (C) -> (D) -> E, A, B, C, D) -> E
 
-fn apply5[A, B, C, D, E, F]((A) -> (B) -> (C) -> (D) -> (E) -> F, A, B, C, D, E) -> F
+fn[A, B, C, D, E, F] apply5((A) -> (B) -> (C) -> (D) -> (E) -> F, A, B, C, D, E) -> F
 
-fn apply6[A, B, C, D, E, F, G]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G, A, B, C, D, E, F) -> G
+fn[A, B, C, D, E, F, G] apply6((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G, A, B, C, D, E, F) -> G
 
-fn apply7[A, B, C, D, E, F, G, H]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H, A, B, C, D, E, F, G) -> H
+fn[A, B, C, D, E, F, G, H] apply7((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H, A, B, C, D, E, F, G) -> H
 
-fn apply8[A, B, C, D, E, F, G, H, I]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I, A, B, C, D, E, F, G, H) -> I
+fn[A, B, C, D, E, F, G, H, I] apply8((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I, A, B, C, D, E, F, G, H) -> I
 
-fn apply9[A, B, C, D, E, F, G, H, I, J]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J, A, B, C, D, E, F, G, H, I) -> J
+fn[A, B, C, D, E, F, G, H, I, J] apply9((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J, A, B, C, D, E, F, G, H, I) -> J
 
-fn compose[A, B, C]((B) -> C, (A) -> B) -> (A) -> C
+fn[A, B, C] compose((B) -> C, (A) -> B) -> (A) -> C
 
-fn compose2[A, B, C, D]((C) -> D, (A) -> (B) -> C) -> (A) -> (B) -> D
+fn[A, B, C, D] compose2((C) -> D, (A) -> (B) -> C) -> (A) -> (B) -> D
 
-fn compose3[A, B, C, D, E]((D) -> E, (A) -> (B) -> (C) -> D) -> (A) -> (B) -> (C) -> E
+fn[A, B, C, D, E] compose3((D) -> E, (A) -> (B) -> (C) -> D) -> (A) -> (B) -> (C) -> E
 
-fn compose4[A, B, C, D, E, F]((E) -> F, (A) -> (B) -> (C) -> (D) -> E) -> (A) -> (B) -> (C) -> (D) -> F
+fn[A, B, C, D, E, F] compose4((E) -> F, (A) -> (B) -> (C) -> (D) -> E) -> (A) -> (B) -> (C) -> (D) -> F
 
-fn const_[A, B](A) -> (B) -> A
+fn[A, B] const_(A) -> (B) -> A
 
-fn curry[A, B, C]((A, B) -> C) -> (A) -> (B) -> C
+fn[A, B, C] curry((A, B) -> C) -> (A) -> (B) -> C
 
-fn curry10[A, B, C, D, E, F, G, H, I, J, K]((A, B, C, D, E, F, G, H, I, J) -> K) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K
+fn[A, B, C, D, E, F, G, H, I, J, K] curry10((A, B, C, D, E, F, G, H, I, J) -> K) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K
 
-fn curry11[A, B, C, D, E, F, G, H, I, J, K, L]((A, B, C, D, E, F, G, H, I, J, K) -> L) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L
+fn[A, B, C, D, E, F, G, H, I, J, K, L] curry11((A, B, C, D, E, F, G, H, I, J, K) -> L) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L
 
-fn curry12[A, B, C, D, E, F, G, H, I, J, K, L, M]((A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M] curry12((A, B, C, D, E, F, G, H, I, J, K, L) -> M) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M
 
-fn curry13[A, B, C, D, E, F, G, H, I, J, K, L, M, N]((A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N] curry13((A, B, C, D, E, F, G, H, I, J, K, L, M) -> N) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N
 
-fn curry14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]((A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] curry14((A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O
 
-fn curry15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] curry15((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P
 
-fn curry16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] curry16((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q
 
-fn curry17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] curry17((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R
 
-fn curry18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] curry18((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S
 
-fn curry19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] curry19((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T
 
-fn curry2[A, B, C]((A, B) -> C) -> (A) -> (B) -> C
+fn[A, B, C] curry2((A, B) -> C) -> (A) -> (B) -> C
 
-fn curry20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] curry20((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U
 
-fn curry21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] curry21((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V
 
-fn curry22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] curry22((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W
 
-fn curry23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] curry23((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X
 
-fn curry24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y] curry24((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y
 
-fn curry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z] curry25((A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z
 
-fn curry3[A, B, C, D]((A, B, C) -> D) -> (A) -> (B) -> (C) -> D
+fn[A, B, C, D] curry3((A, B, C) -> D) -> (A) -> (B) -> (C) -> D
 
-fn curry4[A, B, C, D, E]((A, B, C, D) -> E) -> (A) -> (B) -> (C) -> (D) -> E
+fn[A, B, C, D, E] curry4((A, B, C, D) -> E) -> (A) -> (B) -> (C) -> (D) -> E
 
-fn curry5[A, B, C, D, E, F]((A, B, C, D, E) -> F) -> (A) -> (B) -> (C) -> (D) -> (E) -> F
+fn[A, B, C, D, E, F] curry5((A, B, C, D, E) -> F) -> (A) -> (B) -> (C) -> (D) -> (E) -> F
 
-fn curry6[A, B, C, D, E, F, G]((A, B, C, D, E, F) -> G) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G
+fn[A, B, C, D, E, F, G] curry6((A, B, C, D, E, F) -> G) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G
 
-fn curry7[A, B, C, D, E, F, G, H]((A, B, C, D, E, F, G) -> H) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H
+fn[A, B, C, D, E, F, G, H] curry7((A, B, C, D, E, F, G) -> H) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H
 
-fn curry8[A, B, C, D, E, F, G, H, I]((A, B, C, D, E, F, G, H) -> I) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I
+fn[A, B, C, D, E, F, G, H, I] curry8((A, B, C, D, E, F, G, H) -> I) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I
 
-fn curry9[A, B, C, D, E, F, G, H, I, J]((A, B, C, D, E, F, G, H, I) -> J) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J
+fn[A, B, C, D, E, F, G, H, I, J] curry9((A, B, C, D, E, F, G, H, I) -> J) -> (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J
 
-fn flip[A, B, C]((A) -> (B) -> C) -> (B) -> (A) -> C
+fn[A, B, C] flip((A) -> (B) -> C) -> (B) -> (A) -> C
 
-fn id[A](A) -> A
+fn[A] id(A) -> A
 
-fn negate[A]((A) -> Bool) -> (A) -> Bool
+fn[A] negate((A) -> Bool) -> (A) -> Bool
 
-fn uncurry10[A, B, C, D, E, F, G, H, I, J, K]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K) -> (A, B, C, D, E, F, G, H, I, J) -> K
+fn[A, B, C, D, E, F, G, H, I, J, K] uncurry10((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K) -> (A, B, C, D, E, F, G, H, I, J) -> K
 
-fn uncurry11[A, B, C, D, E, F, G, H, I, J, K, L]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L) -> (A, B, C, D, E, F, G, H, I, J, K) -> L
+fn[A, B, C, D, E, F, G, H, I, J, K, L] uncurry11((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L) -> (A, B, C, D, E, F, G, H, I, J, K) -> L
 
-fn uncurry12[A, B, C, D, E, F, G, H, I, J, K, L, M]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M) -> (A, B, C, D, E, F, G, H, I, J, K, L) -> M
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M] uncurry12((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M) -> (A, B, C, D, E, F, G, H, I, J, K, L) -> M
 
-fn uncurry13[A, B, C, D, E, F, G, H, I, J, K, L, M, N]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N) -> (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N] uncurry13((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N) -> (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N
 
-fn uncurry14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] uncurry14((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O
 
-fn uncurry15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] uncurry15((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P
 
-fn uncurry16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] uncurry16((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q
 
-fn uncurry17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] uncurry17((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R
 
-fn uncurry18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] uncurry18((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S
 
-fn uncurry19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] uncurry19((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T
 
-fn uncurry2[A, B, C]((A) -> (B) -> C) -> (A, B) -> C
+fn[A, B, C] uncurry2((A) -> (B) -> C) -> (A, B) -> C
 
-fn uncurry20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] uncurry20((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U
 
-fn uncurry21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] uncurry21((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V
 
-fn uncurry22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] uncurry22((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W
 
-fn uncurry23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] uncurry23((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X
 
-fn uncurry24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y] uncurry24((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y
 
-fn uncurry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z
+fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z] uncurry25((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z
 
-fn uncurry3[A, B, C, D]((A) -> (B) -> (C) -> D) -> (A, B, C) -> D
+fn[A, B, C, D] uncurry3((A) -> (B) -> (C) -> D) -> (A, B, C) -> D
 
-fn uncurry4[A, B, C, D, E]((A) -> (B) -> (C) -> (D) -> E) -> (A, B, C, D) -> E
+fn[A, B, C, D, E] uncurry4((A) -> (B) -> (C) -> (D) -> E) -> (A, B, C, D) -> E
 
-fn uncurry5[A, B, C, D, E, F]((A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F
+fn[A, B, C, D, E, F] uncurry5((A) -> (B) -> (C) -> (D) -> (E) -> F) -> (A, B, C, D, E) -> F
 
-fn uncurry6[A, B, C, D, E, F, G]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G) -> (A, B, C, D, E, F) -> G
+fn[A, B, C, D, E, F, G] uncurry6((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G) -> (A, B, C, D, E, F) -> G
 
-fn uncurry7[A, B, C, D, E, F, G, H]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H) -> (A, B, C, D, E, F, G) -> H
+fn[A, B, C, D, E, F, G, H] uncurry7((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H) -> (A, B, C, D, E, F, G) -> H
 
-fn uncurry8[A, B, C, D, E, F, G, H, I]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I) -> (A, B, C, D, E, F, G, H) -> I
+fn[A, B, C, D, E, F, G, H, I] uncurry8((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I) -> (A, B, C, D, E, F, G, H) -> I
 
-fn uncurry9[A, B, C, D, E, F, G, H, I, J]((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J) -> (A, B, C, D, E, F, G, H, I) -> J
+fn[A, B, C, D, E, F, G, H, I, J] uncurry9((A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J) -> (A, B, C, D, E, F, G, H, I) -> J
+
+// Errors
 
 // Types and methods
 
 // Type aliases
-pub typealias Arrow[A, B] = (A) -> B
+pub typealias (A) -> B as Arrow[A, B]
 
-pub typealias Arrow10[A, B, C, D, E, F, G, H, I, J, K] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> K as Arrow10[A, B, C, D, E, F, G, H, I, J, K]
 
-pub typealias Arrow11[A, B, C, D, E, F, G, H, I, J, K, L] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> L as Arrow11[A, B, C, D, E, F, G, H, I, J, K, L]
 
-pub typealias Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> M as Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M]
 
-pub typealias Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> N as Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
 
-pub typealias Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> O as Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
 
-pub typealias Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> P as Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
 
-pub typealias Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> Q as Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
 
-pub typealias Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> R as Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
 
-pub typealias Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> S as Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
 
-pub typealias Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> T as Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
 
-pub typealias Arrow2[A, B, C] = (A) -> (B) -> C
+pub typealias (A) -> (B) -> C as Arrow2[A, B, C]
 
-pub typealias Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> U as Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
 
-pub typealias Arrow21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> V as Arrow21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V]
 
-pub typealias Arrow22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> W as Arrow22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W]
 
-pub typealias Arrow23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> X as Arrow23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X]
 
-pub typealias Arrow24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> Y as Arrow24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y]
 
-pub typealias Arrow25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> (J) -> (K) -> (L) -> (M) -> (N) -> (O) -> (P) -> (Q) -> (R) -> (S) -> (T) -> (U) -> (V) -> (W) -> (X) -> (Y) -> Z as Arrow25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z]
 
-pub typealias Arrow3[A, B, C, D] = (A) -> (B) -> (C) -> D
+pub typealias (A) -> (B) -> (C) -> D as Arrow3[A, B, C, D]
 
-pub typealias Arrow4[A, B, C, D, E] = (A) -> (B) -> (C) -> (D) -> E
+pub typealias (A) -> (B) -> (C) -> (D) -> E as Arrow4[A, B, C, D, E]
 
-pub typealias Arrow5[A, B, C, D, E, F] = (A) -> (B) -> (C) -> (D) -> (E) -> F
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> F as Arrow5[A, B, C, D, E, F]
 
-pub typealias Arrow6[A, B, C, D, E, F, G] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> G as Arrow6[A, B, C, D, E, F, G]
 
-pub typealias Arrow7[A, B, C, D, E, F, G, H] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> H as Arrow7[A, B, C, D, E, F, G, H]
 
-pub typealias Arrow8[A, B, C, D, E, F, G, H, I] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> I as Arrow8[A, B, C, D, E, F, G, H, I]
 
-pub typealias Arrow9[A, B, C, D, E, F, G, H, I, J] = (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J
+pub typealias (A) -> (B) -> (C) -> (D) -> (E) -> (F) -> (G) -> (H) -> (I) -> J as Arrow9[A, B, C, D, E, F, G, H, I, J]
 
 // Traits
 

--- a/src/post_compose.mbt
+++ b/src/post_compose.mbt
@@ -1,28 +1,28 @@
 ///|
-pub fn compose[A, B, C](f : Arrow[B, C], g : Arrow[A, B]) -> Arrow[A, C] {
+pub fn[A, B, C] compose(f : Arrow[B, C], g : Arrow[A, B]) -> Arrow[A, C] {
   fn(x) { f(g(x)) }
 }
 
 ///|
-pub fn compose2[A, B, C, D](
+pub fn[A, B, C, D] compose2(
   f : Arrow[C, D],
-  g : Arrow2[A, B, C]
+  g : Arrow2[A, B, C],
 ) -> Arrow2[A, B, D] {
   fn(x) { fn(y) { f(g(x)(y)) } }
 }
 
 ///|
-pub fn compose3[A, B, C, D, E](
+pub fn[A, B, C, D, E] compose3(
   f : Arrow[D, E],
-  g : Arrow3[A, B, C, D]
+  g : Arrow3[A, B, C, D],
 ) -> Arrow3[A, B, C, E] {
   fn(x) { fn(y) { fn(z) { f(g(x)(y)(z)) } } }
 }
 
 ///|
-pub fn compose4[A, B, C, D, E, F](
+pub fn[A, B, C, D, E, F] compose4(
   f : Arrow[E, F],
-  g : Arrow4[A, B, C, D, E]
+  g : Arrow4[A, B, C, D, E],
 ) -> Arrow4[A, B, C, D, F] {
   fn(w) { fn(x) { fn(y) { fn(z) { f(g(w)(x)(y)(z)) } } } }
 }

--- a/src/top.mbt
+++ b/src/top.mbt
@@ -3,7 +3,7 @@ pub fn[A] id(x : A) -> A = "%identity"
 
 ///|
 pub fn[A, B] const_(t : A) -> Arrow[B, A] {
-  fn { _ => t }
+  fn(_) { t }
 }
 
 ///|

--- a/src/top.mbt
+++ b/src/top.mbt
@@ -1,17 +1,17 @@
 ///|
-pub fn id[A](x : A) -> A = "%identity"
+pub fn[A] id(x : A) -> A = "%identity"
 
 ///|
-pub fn const_[A, B](t : A) -> Arrow[B, A] {
+pub fn[A, B] const_(t : A) -> Arrow[B, A] {
   fn { _ => t }
 }
 
 ///|
-pub fn flip[A, B, C](f : Arrow2[A, B, C]) -> Arrow2[B, A, C] {
+pub fn[A, B, C] flip(f : Arrow2[A, B, C]) -> Arrow2[B, A, C] {
   fn(x : B) { fn(y : A) { f(y)(x) } }
 }
 
 ///|
-pub fn negate[A](f : Arrow[A, Bool]) -> Arrow[A, Bool] {
+pub fn[A] negate(f : Arrow[A, Bool]) -> Arrow[A, Bool] {
   fn(x) { not(f(x)) }
 }

--- a/src/uncurry.mbt
+++ b/src/uncurry.mbt
@@ -1,72 +1,72 @@
 ///|
-pub fn uncurry2[A, B, C](func : Arrow2[A, B, C]) -> (A, B) -> C {
+pub fn[A, B, C] uncurry2(func : Arrow2[A, B, C]) -> (A, B) -> C {
   fn(a, b) { func(a)(b) }
 }
 
 ///|
-pub fn uncurry3[A, B, C, D](func : Arrow3[A, B, C, D]) -> (A, B, C) -> D {
+pub fn[A, B, C, D] uncurry3(func : Arrow3[A, B, C, D]) -> (A, B, C) -> D {
   fn(a, b, c) { func(a)(b)(c) }
 }
 
 ///|
-pub fn uncurry4[A, B, C, D, E](
-  func : Arrow4[A, B, C, D, E]
+pub fn[A, B, C, D, E] uncurry4(
+  func : Arrow4[A, B, C, D, E],
 ) -> (A, B, C, D) -> E {
   fn(a, b, c, d) { func(a)(b)(c)(d) }
 }
 
 ///|
-pub fn uncurry5[A, B, C, D, E, F](
-  func : Arrow5[A, B, C, D, E, F]
+pub fn[A, B, C, D, E, F] uncurry5(
+  func : Arrow5[A, B, C, D, E, F],
 ) -> (A, B, C, D, E) -> F {
   fn(a, b, c, d, e) { func(a)(b)(c)(d)(e) }
 }
 
 ///|
-pub fn uncurry6[A, B, C, D, E, F, G](
-  func : Arrow6[A, B, C, D, E, F, G]
+pub fn[A, B, C, D, E, F, G] uncurry6(
+  func : Arrow6[A, B, C, D, E, F, G],
 ) -> (A, B, C, D, E, F) -> G {
   fn(a, b, c, d, e, f) { func(a)(b)(c)(d)(e)(f) }
 }
 
 ///|
-pub fn uncurry7[A, B, C, D, E, F, G, H](
-  func : Arrow7[A, B, C, D, E, F, G, H]
+pub fn[A, B, C, D, E, F, G, H] uncurry7(
+  func : Arrow7[A, B, C, D, E, F, G, H],
 ) -> (A, B, C, D, E, F, G) -> H {
   fn(a, b, c, d, e, f, g) { func(a)(b)(c)(d)(e)(f)(g) }
 }
 
 ///|
-pub fn uncurry8[A, B, C, D, E, F, G, H, I](
-  func : Arrow8[A, B, C, D, E, F, G, H, I]
+pub fn[A, B, C, D, E, F, G, H, I] uncurry8(
+  func : Arrow8[A, B, C, D, E, F, G, H, I],
 ) -> (A, B, C, D, E, F, G, H) -> I {
   fn(a, b, c, d, e, f, g, h) { func(a)(b)(c)(d)(e)(f)(g)(h) }
 }
 
 ///|
-pub fn uncurry9[A, B, C, D, E, F, G, H, I, J](
-  func : Arrow9[A, B, C, D, E, F, G, H, I, J]
+pub fn[A, B, C, D, E, F, G, H, I, J] uncurry9(
+  func : Arrow9[A, B, C, D, E, F, G, H, I, J],
 ) -> (A, B, C, D, E, F, G, H, I) -> J {
   fn(a, b, c, d, e, f, g, h, i) { func(a)(b)(c)(d)(e)(f)(g)(h)(i) }
 }
 
 ///|
-pub fn uncurry10[A, B, C, D, E, F, G, H, I, J, K](
-  func : Arrow10[A, B, C, D, E, F, G, H, I, J, K]
+pub fn[A, B, C, D, E, F, G, H, I, J, K] uncurry10(
+  func : Arrow10[A, B, C, D, E, F, G, H, I, J, K],
 ) -> (A, B, C, D, E, F, G, H, I, J) -> K {
   fn(a, b, c, d, e, f, g, h, i, j) { func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j) }
 }
 
 ///|
-pub fn uncurry11[A, B, C, D, E, F, G, H, I, J, K, L](
-  func : Arrow11[A, B, C, D, E, F, G, H, I, J, K, L]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L] uncurry11(
+  func : Arrow11[A, B, C, D, E, F, G, H, I, J, K, L],
 ) -> (A, B, C, D, E, F, G, H, I, J, K) -> L {
   fn(a, b, c, d, e, f, g, h, i, j, k) { func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k) }
 }
 
 ///|
-pub fn uncurry12[A, B, C, D, E, F, G, H, I, J, K, L, M](
-  func : Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M] uncurry12(
+  func : Arrow12[A, B, C, D, E, F, G, H, I, J, K, L, M],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L) -> M {
   fn(a, b, c, d, e, f, g, h, i, j, k, l) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)
@@ -74,8 +74,8 @@ pub fn uncurry12[A, B, C, D, E, F, G, H, I, J, K, L, M](
 }
 
 ///|
-pub fn uncurry13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](
-  func : Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N] uncurry13(
+  func : Arrow13[A, B, C, D, E, F, G, H, I, J, K, L, M, N],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M) -> N {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)
@@ -83,8 +83,8 @@ pub fn uncurry13[A, B, C, D, E, F, G, H, I, J, K, L, M, N](
 }
 
 ///|
-pub fn uncurry14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](
-  func : Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O] uncurry14(
+  func : Arrow14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N) -> O {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)
@@ -92,8 +92,8 @@ pub fn uncurry14[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O](
 }
 
 ///|
-pub fn uncurry15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](
-  func : Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P] uncurry15(
+  func : Arrow15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O) -> P {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)
@@ -101,8 +101,8 @@ pub fn uncurry15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P](
 }
 
 ///|
-pub fn uncurry16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](
-  func : Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q] uncurry16(
+  func : Arrow16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P) -> Q {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)
@@ -110,8 +110,8 @@ pub fn uncurry16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q](
 }
 
 ///|
-pub fn uncurry17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](
-  func : Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R] uncurry17(
+  func : Arrow17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q) -> R {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)
@@ -119,8 +119,8 @@ pub fn uncurry17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R](
 }
 
 ///|
-pub fn uncurry18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](
-  func : Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S] uncurry18(
+  func : Arrow18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R) -> S {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)
@@ -128,8 +128,8 @@ pub fn uncurry18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S](
 }
 
 ///|
-pub fn uncurry19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
-  func : Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T] uncurry19(
+  func : Arrow19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S) -> T {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)
@@ -137,8 +137,8 @@ pub fn uncurry19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T](
 }
 
 ///|
-pub fn uncurry20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
-  func : Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U]
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U] uncurry20(
+  func : Arrow20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T) -> U {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)
@@ -146,7 +146,7 @@ pub fn uncurry20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U](
 }
 
 ///|
-pub fn uncurry21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V] uncurry21(
   func : Arrow21[
     A,
     B,
@@ -170,7 +170,7 @@ pub fn uncurry21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
     T,
     U,
     V,
-  ]
+  ],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U) -> V {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)
@@ -178,7 +178,7 @@ pub fn uncurry21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
 }
 
 ///|
-pub fn uncurry22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W] uncurry22(
   func : Arrow22[
     A,
     B,
@@ -203,7 +203,7 @@ pub fn uncurry22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
     U,
     V,
     W,
-  ]
+  ],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V) -> W {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)
@@ -211,7 +211,7 @@ pub fn uncurry22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
 }
 
 ///|
-pub fn uncurry23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X](
+pub fn[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X] uncurry23(
   func : Arrow23[
     A,
     B,
@@ -237,7 +237,7 @@ pub fn uncurry23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
     V,
     W,
     X,
-  ]
+  ],
 ) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W) -> X {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)(w)
@@ -245,7 +245,33 @@ pub fn uncurry23[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
 }
 
 ///|
-pub fn uncurry24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y](
+pub fn[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+] uncurry24(
   func : Arrow24[
     A,
     B,
@@ -272,16 +298,42 @@ pub fn uncurry24[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
     W,
     X,
     Y,
-  ]
-) ->
-     (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y {
+  ],
+) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X) -> Y {
   fn(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)(w)(x)
   }
 }
 
 ///|
-pub fn uncurry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y, Z](
+pub fn[
+  A,
+  B,
+  C,
+  D,
+  E,
+  F,
+  G,
+  H,
+  I,
+  J,
+  K,
+  L,
+  M,
+  N,
+  O,
+  P,
+  Q,
+  R,
+  S,
+  T,
+  U,
+  V,
+  W,
+  X,
+  Y,
+  Z,
+] uncurry25(
   func : Arrow25[
     A,
     B,
@@ -309,9 +361,8 @@ pub fn uncurry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
     X,
     Y,
     Z,
-  ]
-) ->
-     (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z {
+  ],
+) -> (A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, V, W, X, Y) -> Z {
   fn(
     a,
     b,
@@ -337,7 +388,7 @@ pub fn uncurry25[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, 
     v,
     w,
     x,
-    y
+    y,
   ) {
     func(a)(b)(c)(d)(e)(f)(g)(h)(i)(j)(k)(l)(m)(n)(o)(p)(q)(r)(s)(t)(u)(v)(w)(x)(
       y,


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Replace deprecated `fn { .. }` syntax with modern `fn(..) { .. }` syntax in src/top.mbt to resolve compiler warning[0027]. The anonymous matrix function syntax has been updated to align with current MoonBit standards.